### PR TITLE
Build: Use git submodule for `cnine` dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,9 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -30,15 +32,6 @@ jobs:
         pip install wheel
         # torch cpu version
         pip install --extra-index-url https://download.pytorch.org/whl/cpu torch
-        # cnine
-        ## needs to be installed in environment mode
-        ## in same directory level as GElib
-        cd ..
-        git clone https://github.com/risi-kondor/cnine.git
-        cd cnine/python
-        # pip install --no-build-isolation -e .
-        cd ../../GElib  
-        # GElib
         cd python
         pip install --no-build-isolation -e .
         cd ..

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/cnine"]
+	path = deps/cnine
+	url = https://github.com/risi-kondor/cnine.git

--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ def main():
 #        compile_with_cuda=False
 
     cwd = os.getcwd()
-    cnine_folder = "/../../cnine/"
+    cnine_folder = "/../deps/cnine/"
     ext_cuda_folder = "../cuda/"
     #ext_cuda_folder = "../../GElib-cuda/cuda/"
 


### PR DESCRIPTION
This commit refactors the project's dependency on the `cnine` library, replacing a hard-coded local filesystem path with a git submodule.

The previous method was brittle and non-portable, requiring developers to manually place the dependency at a specific, machine-dependent location. This created significant friction for new contributors and made reproducible builds difficult to achieve. Using a git submodule resolves these issues by introducing a more robust, standard practice for managing source-level dependencies. The key benefits are:

* **Guaranteed Reproducibility via Version Pinning:** The submodule is pinned to a specific commit hash of the `cnine` repository. This guarantees that every developer, on any machine, will compile against the *exact* same version of the library's source code, eliminating "works on my machine" issues caused by version skew.

* **Enhanced Portability & Simplified Onboarding:** The dependency is now defined relative to the project root and managed by Git. A new contributor can get a fully functional setup with a single command (`git clone --recurse-submodules`), without needing to manually clone other repos into undocumented local directories. This is critical for collaboration within a research team and across different systems (e.g., local workstations, university clusters).

* **Declarative and Explicit Dependency Management:** The `.gitmodules` file acts as a clear, version-controlled manifest of the project's external source dependencies. This makes the project structure more transparent and easier to reason about, akin to how build systems like CMake declare library dependencies. 

* **Standardized Approach:** Using git submodules is a much more "standard practice" than hard-coded paths, allowing for simpler reasoning and understanding by other C++ developers.

Overall, this change makes the project significantly more robust, portable, and easier for current and future team members to develop and maintain.